### PR TITLE
add tabindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [UNRELEASED]
 
+## [1.0.3] - 2016-10-21
+
+### Fixed
+- added `tabindex="0"` to make certain buttons "focusable"
+
 ## [1.0.2] - 2016-10-02
 
 ### Changed
@@ -21,6 +26,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Added
 - new helpers package
 
-[unreleased]: https://github.com/browner12/helpers/compare/v1.0.2...HEAD
+[unreleased]: https://github.com/browner12/helpers/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/browner12/helpers/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/browner12/helpers/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/browner12/helpers/compare/v1.0.0...v1.0.1

--- a/src/Helpers/buttons.php
+++ b/src/Helpers/buttons.php
@@ -152,7 +152,7 @@ if (!function_exists('deleteButton')) {
         $return .= $title;
         $return .= '" data-message="';
         $return .= $message;
-        $return .= '" title="';
+        $return .= '" tabindex="0" title="';
         $return .= $buttonTitle;
         $return .= '"><i class="fa fa-times"></i></a>';
 
@@ -181,7 +181,7 @@ if (!function_exists('cancelButton')) {
         $return .= $title;
         $return .= '" data-message="';
         $return .= $message;
-        $return .= '" title="';
+        $return .= '" tabindex="0" title="';
         $return .= $buttonTitle;
         $return .= '"><i class="fa fa-minus-square"></i></a>';
 
@@ -221,7 +221,7 @@ if (!function_exists('myButton')) {
         $return .= $title;
         $return .= '" data-message="';
         $return .= $message;
-        $return .= '" title="';
+        $return .= '" tabindex="0" title="';
         $return .= $buttonTitle;
         $return .= '"><i class="fa fa-minus-square"></i></a>';
 


### PR DESCRIPTION
some of the buttons were not “focusable” due to them lacking an `href`.
the `tabindex=“0”` makes them focusable again and places them in their
normal tab index order.
