### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/console": "~5.2",
-        "illuminate/contracts": "~5.2",
-        "illuminate/support": "~5.2"
+        "illuminate/console": "5.2.*||5.3.*||5.4.*||5.5.*",
+        "illuminate/contracts": "5.2.*||5.3.*||5.4.*||5.5.*",
+        "illuminate/support": "5.2.*||5.3.*||5.4.*||5.5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
Normal laravel semantic versioning changes.

Also i don't think it is good to support older versions. So it is better to release a new version bumping the minimum PHP level to 7.0 to 7.1 and Laravel 5.5 with Phpunit 6 