### PR TITLE
add default values for not set config value

### DIFF
--- a/src/HelperServiceProvider.php
+++ b/src/HelperServiceProvider.php
@@ -27,9 +27,9 @@ class HelperServiceProvider extends ServiceProvider
         }
 
         //load custom helpers with a mapper
-        if (count(config('helpers.custom_helpers'))) {
+        if (count(config('helpers.custom_helpers', []))) {
 
-            foreach (config('helpers.custom_helpers') as $customHelper) {
+            foreach (config('helpers.custom_helpers', []) as $customHelper) {
 
                 $file = app_path() . '/' . $this->getHelpersDirectory() . '/' . $customHelper . '.php';
 


### PR DESCRIPTION
calling `count()` with a parameter that is a scalar, null, or an object that doesn't implement Countable will generate a warning in PHP 7.2