### PR TITLE
Replace stub "DummyFunction" with function name

### DIFF
--- a/src/Commands/HelperMakeCommand.php
+++ b/src/Commands/HelperMakeCommand.php
@@ -45,4 +45,17 @@ class HelperMakeCommand extends GeneratorCommand
     {
         return $rootNamespace . '\\' . config('helpers.directory', 'Helpers');
     }
+
+    /**
+     * Replace the function name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return string
+     */
+    protected function replaceClass($stub, $name)
+    {
+        $class = str_replace($this->getNamespace($name) . '\\', '', $name);
+        return str_replace('DummyFunction', $class, $stub);
+    }
 }


### PR DESCRIPTION
Previously when users would run ``php artisan make:helper my_helper_function`` it would load the stub in like this:
```php
if (!function_exists('DummyFunction')) {

    /**
     * description
     *
     * @param
     * @return
     */
    function DummyFunction()
    {

    }
}
```

This pull request makes the package generate the stub with the user's defined helper name, like so:
```php
if (!function_exists('my_helper_function')) {

    /**
     * description
     *
     * @param
     * @return
     */
    function my_helper_function()
    {

    }
}
```

It's a small, but helpful quality of life change.